### PR TITLE
Fix compilation errors and warnings.

### DIFF
--- a/conversion/Makefile
+++ b/conversion/Makefile
@@ -1,6 +1,6 @@
 #### Compiler and tool definitions shared by all build targets #####
 CC = gcc
-BASICOPTS = -O4
+BASICOPTS = -O3
 CFLAGS = $(BASICOPTS)
 
 

--- a/conversion/pregraphcode2multicode.c
+++ b/conversion/pregraphcode2multicode.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <string.h>
 
 #include "../multicode/shared/multicode_base.h"
 #include "../multicode/shared/multicode_output.h"

--- a/cubic/cubic_are_matching_vertices_in_dominating_cycle.c
+++ b/cubic/cubic_are_matching_vertices_in_dominating_cycle.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "shared/cubic_base.h"
 #include "shared/cubic_input.h"

--- a/cubic/cubic_extend_matching_to_dominating_cycle.c
+++ b/cubic/cubic_extend_matching_to_dominating_cycle.c
@@ -260,7 +260,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < matchingSize; i++){
         if(sscanf(argv[optind + i], "%d,%d", matchingEdges[i], matchingEdges[i]+1)!=2){
-            fprintf(stderr, "Error while reading matching.\n", c);
+            fprintf(stderr, "Error while reading matching.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/cubic/cubic_is_matching_and_vertices_in_dominating_cycle.c
+++ b/cubic/cubic_is_matching_and_vertices_in_dominating_cycle.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "shared/cubic_base.h"
 #include "shared/cubic_input.h"

--- a/cubic/cubic_is_matching_in_dominating_cycle2.c
+++ b/cubic/cubic_is_matching_in_dominating_cycle2.c
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "shared/cubic_base.h"
 #include "shared/cubic_input.h"

--- a/invariants/multi_invariant_is_hamiltonian_connected.c
+++ b/invariants/multi_invariant_is_hamiltonian_connected.c
@@ -21,7 +21,7 @@
 
 #include "../multicode/shared/multicode_base.h"
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 boolean currentPath[MAXN+1];
 int pathSequence[MAXN];

--- a/multicode/connect/multi_complete_connect.c
+++ b/multicode/connect/multi_complete_connect.c
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
     }
     
     if (optind == argc) {
-        fprintf(stderr, "Error: number of copies omitted.\n", c);
+        fprintf(stderr, "Error: number of copies omitted.\n");
         usage(name);
         return EXIT_FAILURE;
     }
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < connectionCount; i++){
         if(sscanf(argv[optind + 1 + i], "%d,%d", connections[i], connections[i]+1)!=2){
-            fprintf(stderr, "Error while reading connections to be made.\n", c);
+            fprintf(stderr, "Error while reading connections to be made.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/connect/multi_cyclic_connect.c
+++ b/multicode/connect/multi_cyclic_connect.c
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
     }
     
     if (optind == argc) {
-        fprintf(stderr, "Error: number of copies omitted.\n", c);
+        fprintf(stderr, "Error: number of copies omitted.\n");
         usage(name);
         return EXIT_FAILURE;
     }
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < connectionCount; i++){
         if(sscanf(argv[optind + 1 + i], "%d,%d", connections[i], connections[i]+1)!=2){
-            fprintf(stderr, "Error while reading connections to be made.\n", c);
+            fprintf(stderr, "Error while reading connections to be made.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/connect/multi_path_connect.c
+++ b/multicode/connect/multi_path_connect.c
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
     }
     
     if (optind == argc) {
-        fprintf(stderr, "Error: number of copies omitted.\n", c);
+        fprintf(stderr, "Error: number of copies omitted.\n");
         usage(name);
         return EXIT_FAILURE;
     }
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < connectionCount; i++){
         if(sscanf(argv[optind + 1 + i], "%d,%d", connections[i], connections[i]+1)!=2){
-            fprintf(stderr, "Error while reading connections to be made.\n", c);
+            fprintf(stderr, "Error while reading connections to be made.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/multi_add_edges.c
+++ b/multicode/multi_add_edges.c
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < connectionCount; i++){
         if(sscanf(argv[optind + i], "%d,%d", connections[i], connections[i]+1)!=2){
-            fprintf(stderr, "Error while reading edges to be added.\n", c);
+            fprintf(stderr, "Error while reading edges to be added.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/multi_combine.c
+++ b/multicode/multi_combine.c
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
         int g1;
         int g2;
         if(sscanf(argv[optind + i], "%d,%d", &g1, &g2)!=2){
-            fprintf(stderr, "Error while reading vertices to be identified.\n", c);
+            fprintf(stderr, "Error while reading vertices to be identified.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/multi_edge_orbits.c
+++ b/multicode/multi_edge_orbits.c
@@ -80,7 +80,7 @@ void initNautyRelatedVariables(){
 /* This method translates the internal data structure to nauty's dense graph
  * data structure, so the graph can be passed to nauty.
  */
-inline void translateGraphToNautyDenseGraph(GRAPH graph, ADJACENCY adj){
+static inline void translateGraphToNautyDenseGraph(GRAPH graph, ADJACENCY adj){
     int n, i, j;
     
     n = graph[0][0];
@@ -105,7 +105,7 @@ inline void translateGraphToNautyDenseGraph(GRAPH graph, ADJACENCY adj){
     }
 }
 
-inline void callNauty(){
+static inline void callNauty(){
     
     //call nauty
     generatorCount = 0;

--- a/multicode/multi_identify.c
+++ b/multicode/multi_identify.c
@@ -25,6 +25,8 @@
 #include "shared/multicode_input.h"
 #include "shared/multicode_output.h"
 
+int doFind(int *parents, int element);
+
 void doPathCompress(int *parents, int minimumElement, int maximumElement){
     int i;
     for(i=minimumElement; i<= maximumElement; i++){
@@ -174,7 +176,7 @@ int main(int argc, char** argv) {
         int u;
         int v;
         if(sscanf(argv[optind + i], "%d,%d", &u, &v)!=2){
-            fprintf(stderr, "Error while reading vertices to be identified.\n", c);
+            fprintf(stderr, "Error while reading vertices to be identified.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/multi_non_iso.c
+++ b/multicode/multi_non_iso.c
@@ -89,7 +89,7 @@ unten += 24; oben += 24;
 
 /**********UMWANDELN****************************************************/
 
-umwandeln(g,nautyg,m)
+void umwandeln(g,nautyg,m)
 
 GRAPH g;
 NAUTYGRAPH nautyg;
@@ -230,7 +230,7 @@ return copy;
 
 /****************************EINFUGEN****************************************/
 
-einfugen (gr,adj,v,w)
+void einfugen (gr,adj,v,w)
 GRAPH gr;
 unsigned char adj[knoten+1];
 unsigned char v, w;
@@ -249,7 +249,7 @@ adj[w]++;
 /**************************DECODIERE*****************************************/
 
 
-decodiere(unsigned char *code,GRAPH graph,ADJAZENZ adj,int codelaenge)
+void decodiere(unsigned char *code,GRAPH graph,ADJAZENZ adj,int codelaenge)
 
 {
 int i,j;
@@ -386,7 +386,8 @@ if (knotenzahl=='>') /* koennte ein header sein -- oder 'ne 62, also ausreichend
 	if ((a=='>') && (b=='m')) /*garantiert header*/
 	  { 
 	    gepuffert=0;
-	    while ((ucharpuffer=getc(fil)) != '<');
+	    while ((ucharpuffer=getc(fil)) != '<')
+            ;
 	    /* noch zweimal: */ ucharpuffer=getc(fil); 
 	    if (ucharpuffer!='<') { fprintf(stderr,"Problems with header -- single '<'\n"); exit(1); }
 	    if ((knotenzahl=getc(fil))==EOF) return EOF;
@@ -417,8 +418,7 @@ return 1;
 
 /******************************MAIN************************************/
 
-
-main(argc,argv)
+int main(argc,argv)
 
 int argc;
 char *argv[];

--- a/multicode/multi_remove_edges.c
+++ b/multicode/multi_remove_edges.c
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
     
     for (i = 0; i < edgeCount; i++){
         if(sscanf(argv[optind + i], "%d,%d", edgesToRemove[i], edgesToRemove[i]+1)!=2){
-            fprintf(stderr, "Error while reading edges to be removed.\n", c);
+            fprintf(stderr, "Error while reading edges to be removed.\n");
             usage(name);
             return EXIT_FAILURE;
         }

--- a/multicode/multi_vertex_orbits.c
+++ b/multicode/multi_vertex_orbits.c
@@ -47,7 +47,7 @@ int graphCount = 0;
 /* This method translates the internal data structure to nauty's dense graph
  * data structure, so the graph can be passed to nauty.
  */
-inline void translateGraphToNautyDenseGraph(GRAPH graph, ADJACENCY adj){
+static inline void translateGraphToNautyDenseGraph(GRAPH graph, ADJACENCY adj){
     int n, i, j;
     
     n = graph[0][0];

--- a/multicode/multiread.c
+++ b/multicode/multiread.c
@@ -100,7 +100,7 @@ void writeGraph(GRAPH g) {
 
 }
 
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     GRAPH graph;
     ADJACENCY adj;
     int graphCount, i;

--- a/planar/count_pl.c
+++ b/planar/count_pl.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
-
+#include <string.h>
 
 #ifndef MAXN
 #define MAXN 64            /* the maximum number of vertices */

--- a/planar/multiply_pl.c
+++ b/planar/multiply_pl.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
-
+#include <string.h>
 
 #define MAXN 200            /* the maximum number of vertices */
 #define MAXE (6*MAXN-12)    /* the maximum number of oriented edges */
@@ -326,7 +326,7 @@ void help(char *name) {
     fprintf(stderr, "The program %s makes copies of planar graphs from a file.\n\n", name);
     fprintf(stderr, "Usage\n=====\n");
     fprintf(stderr, " %s n\n\n", name);
-    fprintf(stderr, "where n is the number of copies that must be made of each graph.\n\n", name);
+    fprintf(stderr, "where n is the number of copies that must be made of each graph.\n\n");
     fprintf(stderr, "\nThis program can handle graphs up to %d vertices.\n", MAXN);
     fprintf(stderr, "Recompile with a larger value for MAXN if you need larger graphs.\n\n");
     fprintf(stderr, "Valid options\n=============\n");

--- a/planar/nauty_pl.c
+++ b/planar/nauty_pl.c
@@ -144,7 +144,7 @@ boolean readPlanarCode(FILE *f){
 
 void help(char *name) {
     fprintf(stderr, "The program %s reads plane graphs and uses nauty to determine the\n", name);
-    fprintf(stderr, "automorphism groups of the underlying graphs.\n", name);
+    fprintf(stderr, "automorphism groups of the underlying graphs.\n");
     fprintf(stderr, "Usage\n=====\n");
     fprintf(stderr, " %s [options]\n\n", name);
     fprintf(stderr, "\nThis program can handle graphs up to %d vertices. Recompile if you need larger\n", MAXN);

--- a/planar/non_iso_pl/non_iso_pl.c
+++ b/planar/non_iso_pl/non_iso_pl.c
@@ -172,6 +172,9 @@ int elmarks[MAXE+1];
 #define ISMARKED_EL(x) (elmarks[x]==elmarkvalue)
 #define UNMARKED_EL(x) (elmarks[x]!=elmarkvalue)
 
+int comparenodes(short *, int , SPLAYNODE *);
+void outputnode(SPLAYNODE*);
+int hashit(HASHFIELD *, uint32_t *);
 
 #include "splay.c"
 
@@ -700,7 +703,7 @@ return(test);
 
 /*********************OUTPUTNODE***********************************/
 
-outputnode(SPLAYNODE *liste)
+void outputnode(SPLAYNODE *liste)
 
 {
 static char first=1;
@@ -1809,7 +1812,8 @@ if (*type=='p')
    lauf=3;
    /* jetzt wurden 3 Zeichen gelesen */
    if ((code[1]=='>') && (code[2]=='p')) /*garantiert header*/
-     { while ((ucharpuffer=getc(file)) != '<');
+     { while ((ucharpuffer=getc(file)) != '<')
+         ;
      /* noch zweimal: */ ucharpuffer=getc(file); 
      if (ucharpuffer!='<') { fprintf(stderr,"Problems with header -- single '<'\n"); exit(1); }
      if (!fread(&ucharpuffer,sizeof(unsigned char),1,file)) return(0);
@@ -2015,7 +2019,7 @@ void  subdividedubbelandloop(int colour[])
 
 /*******************MAIN********************************/
 
-main(argc,argv)
+int main(argc,argv)
 
 int argc;
 char *argv[];
@@ -2121,7 +2125,7 @@ while (lesecode(code, &lauf, stdin, &codetype))
 
    if (codetype=='p')
      {
-	if (test=check_code(code,neuer_code)) decodiereplanar(code,map,degree);
+	if ((test=check_code(code,neuer_code))) decodiereplanar(code,map,degree);
 	else { decodiereplanar(neuer_code,map,degree); globaltest++; }
 	for (i=1;i<=nv;i++) colour[i]=degree[i];
      }

--- a/planar/non_iso_pl/splay.c
+++ b/planar/non_iso_pl/splay.c
@@ -343,7 +343,7 @@ SPLAY_LOOKUP(SPLAYNODE **to_root  LOOKUP_ARGS)
 
 /*********************************************************************/
 
-static SPLAYNODE*
+static void
 SPLAY_DELETE(SPLAYNODE **to_root, SPLAYNODE *p)
 /* Remove node p from the tree and free it. */
 {

--- a/planar/select_pl.c
+++ b/planar/select_pl.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
+#include <string.h>
 
 
 #ifndef MAXN

--- a/planar/shared/planar_input.c
+++ b/planar/shared/planar_input.c
@@ -7,6 +7,7 @@
 
 #include "planar_input.h"
 #include <stdlib.h>
+#include <string.h>
 
 PLANE_GRAPH *decodePlanarCode(unsigned short* code, PG_INPUT_OPTIONS *options) {
     int i, j, codePosition, nv, maxn;

--- a/planar/show_pl.c
+++ b/planar/show_pl.c
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
     
     unsigned short *code;
     DEFAULT_PG_INPUT_OPTIONS(options);
-    while (code = readPlanarCode(stdin, &options)) {
+    while ((code = readPlanarCode(stdin, &options))) {
         if(showCode){
             printCode(code);
         } else {

--- a/planar/split_pl.c
+++ b/planar/split_pl.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
+#include <string.h>
 
 
 #ifndef MAXN

--- a/signed/signed_show.c
+++ b/signed/signed_show.c
@@ -119,7 +119,7 @@ void writeGraph(GRAPH g, int order) {
 
 }
 
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     GRAPH graph;
     ADJACENCY adj;
     int graphCount, i;

--- a/visualise/writegraph2png.c
+++ b/visualise/writegraph2png.c
@@ -8,6 +8,7 @@
 #include "pngtoolkit.h"
 #include <stdlib.h>
 #include <limits.h>
+#include <string.h>
 
 typedef int boolean;
 #define TRUE 1


### PR DESCRIPTION
Building graphtools on my system failed, due to function declaration problems and other issues. I fixed these and went ahead and dealt with some other compiler warnings also: for instance, finding malloc in stdlib.h, not malloc.h.

Beyond these, it would be nice to change all the "-O4" in the Makefile to "-O3", since "-O4" doesn't mean anything to gcc or clang, or any other modern compiler I'm aware of.
